### PR TITLE
docs(ecc): add ECC install guide and wrapper script

### DIFF
--- a/docs/INSTALLING-ECC.md
+++ b/docs/INSTALLING-ECC.md
@@ -1,0 +1,111 @@
+# Installing ECC
+
+[ECC](https://github.com/affaan-m/ECC) is an agent harness for Claude Code that
+ships 60 agents, 232 skills, hooks, language rules, and MCP configs. This guide
+shows the three supported installation paths and how to use the wrapper script
+in `scripts/install-ecc.sh`.
+
+> Requirements: Claude Code CLI v2.1.0+, Node.js, git.
+
+> **Do not stack methods.** The most common broken setup is `/plugin install`
+> followed by `install.sh --profile full`. Pick one path.
+
+---
+
+## Option 1 — Plugin install (recommended)
+
+Run inside Claude Code:
+
+```text
+/plugin marketplace add https://github.com/affaan-m/ECC
+/plugin install ecc@ecc
+```
+
+Plugins cannot distribute rule files. After installing, copy the rules you want:
+
+```bash
+git clone --depth 1 https://github.com/affaan-m/ECC.git /tmp/ecc
+mkdir -p ~/.claude/rules/ecc
+cp -R /tmp/ecc/rules/common      ~/.claude/rules/ecc/
+cp -R /tmp/ecc/rules/typescript  ~/.claude/rules/ecc/   # pick your stack
+```
+
+---
+
+## Option 2 — Wrapper script (this repo)
+
+`scripts/install-ecc.sh` clones ECC into `~/.cache/ecc`, runs `npm install`, and
+invokes the upstream installer.
+
+```bash
+./scripts/install-ecc.sh                       # profile=core, target=claude
+./scripts/install-ecc.sh --profile minimal     # no hooks runtime
+./scripts/install-ecc.sh --profile full        # everything, all language rules
+./scripts/install-ecc.sh --dir /opt/ecc        # custom checkout location
+```
+
+Extra flags are forwarded to the upstream installer, e.g.:
+
+```bash
+./scripts/install-ecc.sh --profile core --without baseline:hooks
+./scripts/install-ecc.sh --target claude --modules hooks-runtime
+```
+
+---
+
+## Option 3 — Manual install
+
+```bash
+git clone https://github.com/affaan-m/ECC.git
+cd ECC
+npm install
+./install.sh --profile full         # macOS / Linux
+# .\install.ps1 --profile full      # Windows PowerShell
+# npx ecc-install --profile full    # cross-platform alternative
+```
+
+---
+
+## Profiles
+
+| Profile   | Contents                                                  | Use case                          |
+|-----------|-----------------------------------------------------------|-----------------------------------|
+| `minimal` | rules, agents, commands, skills (no hooks)                | low-context, no automation        |
+| `core`    | standard components + hooks                               | default                           |
+| `full`    | everything including all language rules                   | complete install                  |
+
+---
+
+## Verifying the install
+
+After install, these should exist:
+
+```bash
+ls ~/.claude/agents     ~/.claude/skills     ~/.claude/commands
+ls ~/.claude/hooks      ~/.claude/rules/ecc  # rules only after manual copy
+```
+
+In Claude Code, `/plugin` lists installed plugins; `/help` should show new
+commands contributed by ECC.
+
+---
+
+## Uninstall / reset
+
+If you stacked installs by accident, use ECC's uninstall script:
+
+```bash
+node ~/.cache/ecc/scripts/uninstall.js --dry-run   # preview
+node ~/.cache/ecc/scripts/uninstall.js             # remove ECC-managed files
+```
+
+---
+
+## Notes for this repo
+
+- This template runs on remote ephemeral containers (Claude Code on the web).
+  ECC components installed into `~/.claude/` in a remote session are wiped when
+  the container is reclaimed. Install ECC on the workstation where you run the
+  Claude Code CLI, not inside a session container.
+- If you want ECC available in CI or web sessions, install it from a
+  `SessionStart` hook — see `skills/session-start-hook` for the pattern.

--- a/scripts/install-ecc.sh
+++ b/scripts/install-ecc.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Install ECC (https://github.com/affaan-m/ECC) into ~/.claude/
+# Usage: ./scripts/install-ecc.sh [--profile minimal|core|full] [--target claude]
+set -euo pipefail
+
+ECC_REPO="https://github.com/affaan-m/ECC.git"
+ECC_DIR="${ECC_DIR:-$HOME/.cache/ecc}"
+PROFILE="core"
+TARGET="claude"
+EXTRA_ARGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --profile)
+      PROFILE="$2"; shift 2 ;;
+    --profile=*)
+      PROFILE="${1#--profile=}"; shift ;;
+    --target)
+      TARGET="$2"; shift 2 ;;
+    --target=*)
+      TARGET="${1#--target=}"; shift ;;
+    --dir)
+      ECC_DIR="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,4p' "$0"; exit 0 ;;
+    *)
+      EXTRA_ARGS+=("$1"); shift ;;
+  esac
+done
+
+case "$PROFILE" in
+  minimal|core|full) ;;
+  *) echo "Invalid profile: $PROFILE (expected: minimal|core|full)" >&2; exit 2 ;;
+esac
+
+command -v git >/dev/null || { echo "git is required" >&2; exit 1; }
+command -v node >/dev/null || { echo "node is required (Claude Code v2.1.0+)" >&2; exit 1; }
+
+if [ -d "$ECC_DIR/.git" ]; then
+  echo "==> Updating ECC checkout in $ECC_DIR"
+  git -C "$ECC_DIR" fetch --depth 1 origin
+  git -C "$ECC_DIR" reset --hard origin/HEAD
+else
+  echo "==> Cloning ECC into $ECC_DIR"
+  mkdir -p "$(dirname "$ECC_DIR")"
+  git clone --depth 1 "$ECC_REPO" "$ECC_DIR"
+fi
+
+cd "$ECC_DIR"
+
+if [ -f package.json ]; then
+  echo "==> Installing npm dependencies"
+  npm install --no-audit --no-fund
+fi
+
+if [ ! -x ./install.sh ]; then
+  echo "install.sh not found or not executable in $ECC_DIR" >&2
+  exit 1
+fi
+
+echo "==> Running ECC installer: --profile $PROFILE --target $TARGET ${EXTRA_ARGS[*]-}"
+./install.sh --profile "$PROFILE" --target "$TARGET" "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"
+
+echo
+echo "ECC installed (profile=$PROFILE)."
+echo "Plugins cannot ship rules; if you want language rules, copy them manually:"
+echo "  mkdir -p ~/.claude/rules/ecc"
+echo "  cp -R $ECC_DIR/rules/common      ~/.claude/rules/ecc/"
+echo "  cp -R $ECC_DIR/rules/typescript  ~/.claude/rules/ecc/   # pick your stack"


### PR DESCRIPTION
## Summary
- Add `docs/INSTALLING-ECC.md` documenting the three supported install paths for [affaan-m/ECC](https://github.com/affaan-m/ECC): plugin marketplace, wrapper script, and manual.
- Add `scripts/install-ecc.sh` — clones ECC into `~/.cache/ecc`, runs `npm install`, then forwards `--profile` / `--target` / extra flags to upstream `install.sh`.
- ECC itself is **not** vendored into this repo; the script fetches it on demand.

## Notes
- Requires Claude Code CLI v2.1.0+, Node.js, and git on the host where ECC is installed.
- Doc calls out that installing into `~/.claude/` from a remote ephemeral session does not persist — install on the workstation that runs the Claude Code CLI, or wire it into a `SessionStart` hook.
- Doc warns against stacking install paths (the common `/plugin install` + `install.sh --profile full` foot-gun).

## Test plan
- [ ] `bash -n scripts/install-ecc.sh` passes (done locally)
- [ ] Run `./scripts/install-ecc.sh --profile minimal` on a workstation and confirm `~/.claude/agents` and `~/.claude/skills` populate
- [ ] Run `./scripts/install-ecc.sh --profile full` and confirm hooks runtime is present
- [ ] Verify `node ~/.cache/ecc/scripts/uninstall.js --dry-run` lists ECC-managed files

https://claude.ai/code/session_014Fkw7o8mmLp2bh5xPSJigT

---
_Generated by [Claude Code](https://claude.ai/code/session_014Fkw7o8mmLp2bh5xPSJigT)_