### PR TITLE
chore(sync): log pulseagent.io registration outage (backend /app/api/* 502)

### DIFF
--- a/.sync/incident-2026-07-registration-502.md
+++ b/.sync/incident-2026-07-registration-502.md
@@ -38,6 +38,14 @@ so every authenticated call — `register`, `login`, `me`,
 `registration-config`, magic-link, password reset — is down while the
 origin is 502ing.
 
+## Update — escalation timeline (probe observations)
+
+- **~08:00 UTC** — `/app/api/*` returns **502** (origin bad gateway); marketing site + SPA shell healthy (200).
+- **~09:00–13:00 UTC** — `/app/api/*` returns **504** (origin timeout); frontend still 200.
+- **~15:20 UTC** — **522** (Cloudflare→origin connection timed out) now on **all** paths including the homepage (`https://pulseagent.io`), ~20s timeouts. Outage widened from API-only to the whole origin — the origin is now fully unreachable from Cloudflare, not just erroring on API routes.
+
+No recovery observed. Escalation 502 → 504 → 522 (full-site) indicates the origin host/deployment is progressively more unreachable, not self-healing.
+
 ## Fix (out of repo)
 
 The pulseagent.io API backend is **not** part of this template repository

--- a/.sync/incident-2026-07-registration-502.md
+++ b/.sync/incident-2026-07-registration-502.md
@@ -44,7 +44,9 @@ origin is 502ing.
 - **~09:00–13:00 UTC** — `/app/api/*` returns **504** (origin timeout); frontend still 200.
 - **~15:20 UTC** — **522** (Cloudflare→origin connection timed out) now on **all** paths including the homepage (`https://pulseagent.io`), ~20s timeouts. Outage widened from API-only to the whole origin — the origin is now fully unreachable from Cloudflare, not just erroring on API routes.
 
-No recovery observed. Escalation 502 → 504 → 522 (full-site) indicates the origin host/deployment is progressively more unreachable, not self-healing.
+- **~19:35 UTC** — **partial shift**: marketing homepage recovered (**200**, ~0.8s), but `/app/api/*` now **hangs** — requests return 0 bytes and hit the client's 30s timeout (curl exit 28), no Cloudflare error page. The frontend/origin is serving again while the **API backend accepts connections but never responds** (wedged/hung process, distinct from "origin down"). Registration still broken.
+
+No recovery observed. Progression 502 → 504 → 522 (full-site) → home 200 + API hang. The frontend origin came back but the API service is not responding; remediation still targets the API backend (restart the hung API process/workers, not just the web tier).
 
 ## Fix (out of repo)
 

--- a/.sync/incident-2026-07-registration-502.md
+++ b/.sync/incident-2026-07-registration-502.md
@@ -1,6 +1,6 @@
 # Incident — pulseagent.io Registration Failing (Backend 502)
 
-**Status:** OPEN — origin backend outage (not fixable from this repo)
+**Status:** RESOLVED — API backend recovered ~20:41 UTC 2026-07-10; total observed downtime ~12h40m (first 502 ~08:00 UTC → recovery ~20:41 UTC). Origin backend outage, fixed outside this repo.
 **Reported:** user report "pulseagent.io 又无法注册了" (registration broken again)
 **Diagnosed:** 2026-07-10 ~06:26 UTC (per HTTP `Date` headers on probes)
 **Scope:** All `/app/api/*` routes — registration, login, session, config
@@ -47,6 +47,13 @@ origin is 502ing.
 - **~19:35 UTC** — **partial shift**: marketing homepage recovered (**200**, ~0.8s), but `/app/api/*` now **hangs** — requests return 0 bytes and hit the client's 30s timeout (curl exit 28), no Cloudflare error page. The frontend/origin is serving again while the **API backend accepts connections but never responds** (wedged/hung process, distinct from "origin down"). Registration still broken.
 
 No recovery observed. Progression 502 → 504 → 522 (full-site) → home 200 + API hang. The frontend origin came back but the API service is not responding; remediation still targets the API backend (restart the hung API process/workers, not just the web tier).
+
+- **~20:41 UTC — RECOVERED.** All routes return real, fast HTTP responses:
+  home 200, `registration-config` 200, `register`/`login` 405 on GET (POST-only),
+  `me` 401 (no token), and `POST /register` with an empty body → **422**
+  (validation) in ~0.8s. The API backend is processing requests normally
+  again; registration works. No repo change caused or fixed this — it was a
+  backend-side outage that recovered on the operator's side.
 
 ## Fix (out of repo)
 

--- a/.sync/incident-2026-07-registration-502.md
+++ b/.sync/incident-2026-07-registration-502.md
@@ -1,6 +1,6 @@
 # Incident — pulseagent.io Registration Failing (Backend 502)
 
-**Status:** RESOLVED — API backend recovered ~20:41 UTC 2026-07-10; total observed downtime ~12h40m (first 502 ~08:00 UTC → recovery ~20:41 UTC). Origin backend outage, fixed outside this repo.
+**Status:** REOPENED — API is FLAPPING. Recovered ~20:41 UTC, held at ~21:44 UTC, then went down again ~23:16 UTC (home 200 but `/app/api/*` hangs — 0 bytes, 30s timeout). Not a stable recovery; the API backend is unstable. Fix is still on the backend side (out of this repo).
 **Reported:** user report "pulseagent.io 又无法注册了" (registration broken again)
 **Diagnosed:** 2026-07-10 ~06:26 UTC (per HTTP `Date` headers on probes)
 **Scope:** All `/app/api/*` routes — registration, login, session, config
@@ -54,6 +54,9 @@ No recovery observed. Progression 502 → 504 → 522 (full-site) → home 200 +
   (validation) in ~0.8s. The API backend is processing requests normally
   again; registration works. No repo change caused or fixed this — it was a
   backend-side outage that recovered on the operator's side.
+
+- **~21:44 UTC** — still healthy (home 200, registration-config 200, POST /register 422). Recovery held for ~1h.
+- **~23:16 UTC — REGRESSED (flap).** Home still 200, but `/app/api/auth/registration-config` and `POST /register` hang again (000, 30s timeout, 0 bytes) across repeated probes. Same "frontend-up + API-backend-wedged" mode as ~19:35 UTC. The API backend is flapping, not durably fixed — it recovers then wedges again. Root cause is likely an unstable/OOM-restarting or intermittently-hung API process on the origin; needs a real backend fix (not just a restart that lasts ~1h).
 
 ## Fix (out of repo)
 

--- a/.sync/incident-2026-07-registration-502.md
+++ b/.sync/incident-2026-07-registration-502.md
@@ -1,0 +1,61 @@
+# Incident — pulseagent.io Registration Failing (Backend 502)
+
+**Status:** OPEN — origin backend outage (not fixable from this repo)
+**Reported:** user report "pulseagent.io 又无法注册了" (registration broken again)
+**Diagnosed:** 2026-07-10 ~06:26 UTC (per HTTP `Date` headers on probes)
+**Scope:** All `/app/api/*` routes — registration, login, session, config
+
+## Symptom
+
+Users cannot sign up. The signup page loads, then its first API call
+(`GET /app/api/auth/registration-config`) fails and the form can't submit.
+Login is broken by the same cause.
+
+## Probe results
+
+| Layer | URL | Result |
+|-------|-----|--------|
+| Marketing site | `https://pulseagent.io` | 200 OK |
+| App shell (SPA) | `/app/login?lang=en`, `/app/register?lang=en` | 200 OK (static, served by Cloudflare) |
+| Registration config | `/app/api/auth/registration-config` | **502** |
+| Register | `/app/api/auth/register` | **502** |
+| Login | `/app/api/auth/login` | **502** |
+| Session | `/app/api/auth/me` | **502** |
+
+Consistent across 3 retries; all `/app/api/*` endpoints affected.
+
+## Root cause
+
+Cloudflare is healthy and serving the static frontend, but the **origin
+backend behind it is unreachable/erroring**. The 502 responses carry
+`server: cloudflare`, `content-type: text/plain`, `content-length: 16`
+(body: `error code: 502`) — Cloudflare's own bad-gateway page, i.e. the
+API origin is down or crash-looping. This is a full backend/API outage,
+not a registration-specific bug and not a frontend/DNS problem.
+
+The SPA (`/app/assets/index-*.js`) hardcodes API base `Bn = "/app/api"`,
+so every authenticated call — `register`, `login`, `me`,
+`registration-config`, magic-link, password reset — is down while the
+origin is 502ing.
+
+## Fix (out of repo)
+
+The pulseagent.io API backend is **not** part of this template repository
+(`b2b-sdr-agent-template` ships docs, skills, deploy scripts, and the
+`.sync/` content pipeline only). Remediation happens on the backend host:
+
+1. Check the API origin process/container health and logs.
+2. Restart / redeploy the API service; confirm it passes its own health check.
+3. Verify `GET /app/api/auth/registration-config` returns 200 and the
+   signup form submits end-to-end.
+
+## Verification command
+
+```sh
+for p in registration-config register login me; do
+  printf '%s -> ' "$p"
+  curl -s -o /dev/null -w '%{http_code}\n' \
+    "https://pulseagent.io/app/api/auth/$p"
+done
+# All 200 (or 4xx on bad input) = recovered. 502 = still down.
+```

--- a/.sync/sync-log.md
+++ b/.sync/sync-log.md
@@ -1,3 +1,10 @@
+## 2026-07-10 — Incident: pulseagent.io registration down (backend 502)
+- **Trigger**: user report — "pulseagent.io 又无法注册了" (registration broken again).
+- **Probe**: marketing site 200, `/app/*` SPA shell 200, but **all `/app/api/*` routes return 502** (`registration-config`, `register`, `login`, `me`) — consistent across 3 retries. Cloudflare-origin 502 (`server: cloudflare`, 16-byte `error code: 502` body) → API origin backend is down/crash-looping.
+- **Root cause**: pulseagent.io API backend outage. Frontend/DNS healthy; origin unreachable. Not registration-specific — full auth API is down.
+- **Scope**: out of this repo. The `b2b-sdr-agent-template` ships docs/skills/deploy/`.sync` only; the pulseagent.io API is a separate deployment. Fix = restart/redeploy the API origin + confirm `registration-config` returns 200.
+- **Action**: logged incident (`.sync/incident-2026-07-registration-502.md`). No template/blog change. No queue change.
+
 ## 2026-06-14 — Hourly Drain (run #10)
 - **Release check**: last=v2026.6.6, latest stable=v2026.6.6 (v2026.6.9-alpha.4, v2026.6.8-beta.1, v2026.6.8-alpha.2, v2026.6.7-beta.1 skipped — pre-release) → NO NEW RELEASE
 - **WeChat queue drain (Step 0)**: 1 item in queue (v2026.6.6). Re-push attempted → STILL FAILING (HTTP 500, server-side error persists). Queue: 1→1.


### PR DESCRIPTION
## Summary

User reported **"pulseagent.io 又无法注册了"** (registration broken again). I probed the live site to diagnose, then recorded the incident in `.sync/` — matching how this repo already tracks service outages (e.g. the WeChat HTTP-500 queue failures).

## Diagnosis

| Layer | URL | Result |
|-------|-----|--------|
| Marketing site | `https://pulseagent.io` | ✅ 200 |
| App shell (SPA) | `/app/login`, `/app/register` | ✅ 200 (static, via Cloudflare) |
| Registration config | `/app/api/auth/registration-config` | ❌ **502** |
| Register | `/app/api/auth/register` | ❌ **502** |
| Login | `/app/api/auth/login` | ❌ **502** |
| Session | `/app/api/auth/me` | ❌ **502** |

**Root cause:** every `/app/api/*` route returns a Cloudflare-origin `502 Bad Gateway` (`server: cloudflare`, 16-byte `error code: 502` body), consistent across 3 retries. The static frontend is healthy; the **API origin backend is down/crash-looping**. The SPA hardcodes API base `Bn = "/app/api"`, so the failing first call (`GET …/registration-config`) blocks the signup form. This is a full backend auth outage, not a registration-specific bug and not a frontend/DNS issue.

## Scope

The pulseagent.io API backend is **not** part of this template repo (which ships docs, skills, deploy scripts, and the `.sync/` content pipeline only). Remediation is on the backend deployment: restart/redeploy the API origin and confirm `registration-config` returns 200. This PR only records the incident + evidence + a recovery-verification command.

## Files

- `.sync/incident-2026-07-registration-502.md` — full incident report + verification command
- `.sync/sync-log.md` — incident entry prepended

## Verification

```sh
for p in registration-config register login me; do
  printf '%s -> ' "$p"
  curl -s -o /dev/null -w '%{http_code}\n' "https://pulseagent.io/app/api/auth/$p"
done
# 502 = still down · 200/4xx = recovered
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Jm8mfc9PqLepqS93v4H7M

---
_Generated by [Claude Code](https://claude.ai/code/session_019Jm8mfc9PqLepqS93v4H7M)_